### PR TITLE
updated track CytoSNP-850Kv1-2.interval_list

### DIFF
--- a/SNPArray/CytoSNP-850Kv1-2.interval_list
+++ b/SNPArray/CytoSNP-850Kv1-2.interval_list
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:9afdaff927694ccc40e8c3dc68cd5e5d881ca944c21f57de41070b8de28f9541
-size 28052267
+oid sha256:bc4736b5ed08214621692e384c7de405aabd6e32a9ce77b53217c4b5a8594036
+size 28052444


### PR DESCRIPTION
* MT included in header as this could give problems with tools (i.e. PICARD) if not similar to reference genome