### PR TITLE
Sure Select v7 support 

### DIFF
--- a/ExomeDepth/HC_SSv7-2021-1_exon.tsv
+++ b/ExomeDepth/HC_SSv7-2021-1_exon.tsv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4a96d2ac093c5992355a46b2760a230e756a4b15e56c26828f511486ffb7b6e4
+size 9188874

--- a/ExomeDepth/HC_SSv7-2021-1_target.bed
+++ b/ExomeDepth/HC_SSv7-2021-1_target.bed
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4bbef36f9cbb2ac3d218e6b7d7b13d3a815990f50eb7d10fceecee924a28e234
+size 4594424

--- a/ExomeDepth/HC_exon.tsv
+++ b/ExomeDepth/HC_exon.tsv
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:dc6608ff138db63a7a3b8e1edf75f92598648c3a3a953c0c1ea3dbb0f981ca2e
-size 11583478

--- a/ExomeDepth/HC_target.bed
+++ b/ExomeDepth/HC_target.bed
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:4d8aaa6276a88418e5908855d9873c183486446121e4fe40704e6ebb03d4a55e
-size 5791726


### PR DESCRIPTION
* Removed CREv2 high-confident files
* Added new SSv7 high-confident files, with new naming. 